### PR TITLE
Migrate JUnit4 -> JUnit5

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,21 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Build with Maven
+        run: mvn -B test-compile
+      - name: Run tests with Maven
+        timeout-minutes: 10
+        run: mvn -B test

--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ This is the [ipld](https://github.com/ipld/ipld) serialization implementation in
 - [Usage](#usage)
 - [Dependency](#dependency)
 - [Testing](#testing)
-  - [Ant](#ant)
-  - [Maven](#maven)
 - [Building](#building)
-  - [Ant](#ant-1)
-  - [Maven](#maven-1)
 - [Releasing](#releasing)
 - [Maintainers](#maintainers)
 - [Contribute](#contribute)
@@ -31,7 +27,7 @@ Simply clone this repo.
 
 ## Usage
 
-```
+```java
 // Serialization
 List<CborObject> list = new ArrayList<>();
 list.add(new CborObject.CborString("A value"));
@@ -51,7 +47,7 @@ CborObject deserialized = CborObject.fromByteArray(raw);
 You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#ipld/java-ipld-cbor/) (also supporting Gradle, SBT, etc).
 
 for Maven, you can add the follwing sections to your POM.XML:
-```
+```xml
   <repositories>
     <repository>
         <id>jitpack.io</id>
@@ -70,22 +66,15 @@ for Maven, you can add the follwing sections to your POM.XML:
 
 ## Testing
 
-### Ant
-`ant test`
-
-### Maven
 `mvn test`
 
 ## Building
 
-### Ant
-`ant dist` will build a JAR file in the `./dist` suitable for manual inclusion in a project. Dependent libraries are included in `./dist/lib`.
-
-### Maven
 `mvn package` will build a JAR file with Maven dependency information.
 
 ## Releasing
-The version number is specified in `build.xml` and `pom.xml` and must be changed in both places in order to be accurately reflected in the JAR file manifest. A git tag must be added in the format "vx.x.x" for JitPack to work.
+
+The version number is specified in the `pom.xml` file and must be changed in order to be accurately reflected in the JAR file manifest. A git tag must be added in the format "vx.x.x" for JitPack to work.
 
 ## Maintainers
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<junit.version>4.13.1</junit.version>
-		<hamcrest.version>1.3</hamcrest.version>
+		<junit.version>5.11.0</junit.version>
+		<hamcrest.version>3.0</hamcrest.version>
 	</properties>
 
 	<repositories>
@@ -45,8 +45,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -77,7 +77,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>3.1.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/peergos/server/tests/CborObjects.java
+++ b/src/test/java/peergos/server/tests/CborObjects.java
@@ -1,8 +1,12 @@
 package peergos.server.tests;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 import peergos.shared.cbor.*;
+
 import io.ipfs.multihash.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.*;
 
@@ -16,43 +20,43 @@ public class CborObjects {
     }
 
     @Test
-    public void dosCborObject() throws Throwable {
+    void dosCborObject() throws Throwable {
         // make a header for a byte[] that is 2^50 long
         byte[] raw = hexToBytes("5b0004000000000000");
         try {
             CborObject.fromByteArray(raw);
-            Assert.fail("Should have failed!");
+            fail("Should have failed!");
         } catch (RuntimeException e) {}
     }
 
     @Test
-    public void cborNull() {
+    void cborNull() {
         CborObject.CborNull cbor = new CborObject.CborNull();
         compatibleAndIdempotentSerialization(cbor);
     }
 
     @Test
-    public void cborString() {
+    void cborString() {
         String value = "G'day mate!";
         CborObject.CborString cbor = new CborObject.CborString(value);
         compatibleAndIdempotentSerialization(cbor);
     }
 
     @Test
-    public void cborByteArray() {
+    void cborByteArray() {
         byte[] value = random(32);
         CborObject.CborByteArray cbor = new CborObject.CborByteArray(value);
         compatibleAndIdempotentSerialization(cbor);
     }
 
     @Test
-    public void cborBoolean() {
+    void cborBoolean() {
         compatibleAndIdempotentSerialization(new CborObject.CborBoolean(true));
         compatibleAndIdempotentSerialization(new CborObject.CborBoolean(false));
     }
 
     @Test
-    public void cborLongs() {
+    void cborLongs() {
         cborLong(rnd.nextLong());
         cborLong(Long.MAX_VALUE);
         cborLong(Long.MIN_VALUE);
@@ -69,14 +73,14 @@ public class CborObjects {
     }
 
     @Test
-    public void cborMerkleLink() {
+    void cborMerkleLink() {
         Multihash hash = Multihash.fromBase58("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB");
         CborObject.CborMerkleLink link = new CborObject.CborMerkleLink(hash);
         compatibleAndIdempotentSerialization(link);
     }
 
     @Test
-    public void cborMap() {
+    void cborMap() {
         SortedMap<CborObject, CborObject> map = new TreeMap<>();
         map.put(new CborObject.CborString("KEY 1"), new CborObject.CborString("A value"));
         map.put(new CborObject.CborString("KEY 2"), new CborObject.CborByteArray("Another value".getBytes()));
@@ -95,7 +99,7 @@ public class CborObjects {
     }
 
     @Test
-    public void cborList() {
+    void cborList() {
         List<CborObject> list = new ArrayList<>();
         list.add(new CborObject.CborString("A value"));
         list.add(new CborObject.CborByteArray("A value".getBytes()));
@@ -110,10 +114,10 @@ public class CborObjects {
         CborObject deserialized = CborObject.fromByteArray(raw);
 
         boolean equals = deserialized.equals(value);
-        Assert.assertTrue("Equal objects", equals);
+        assertTrue(equals, "Equal objects");
         byte[] raw2 = deserialized.toByteArray();
         boolean sameRaw = Arrays.equals(raw, raw2);
-        Assert.assertTrue("Idempotent serialization", sameRaw);
+        assertTrue(sameRaw, "Idempotent serialization");
     }
 
     public static byte[] hexToBytes(String hex) {


### PR DESCRIPTION
The JUnit5 framework is the successor to JUnit4, and is currently maintained version.
Changes in this PR:
- Tests migrated from JUnit4 to JUnit5 using OpenRewrite
- Dependencies updated
- `README.md` updated
- GitHub workflow added